### PR TITLE
Made Pawns visible while selecting

### DIFF
--- a/ChoukaBaraGame/Scenes/Gara/GaraPopup.tscn
+++ b/ChoukaBaraGame/Scenes/Gara/GaraPopup.tscn
@@ -4,6 +4,7 @@
 [ext_resource path="res://Scripts/Gara/GaraPopup.gd" type="Script" id=2]
 
 [node name="GaraPopup" type="AcceptDialog"]
+visible = true
 anchor_right = 0.646
 anchor_bottom = 0.656
 margin_right = -0.160034
@@ -31,7 +32,7 @@ __meta__ = {
 }
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
-margin_right = 604.0
+margin_right = 707.0
 margin_bottom = 284.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -41,17 +42,17 @@ __meta__ = {
 }
 
 [node name="koude01" parent="VBoxContainer/HBoxContainer2" instance=ExtResource( 1 )]
-margin_right = 300.0
+margin_right = 351.0
 margin_bottom = 284.0
 
 [node name="koude02" parent="VBoxContainer/HBoxContainer2" instance=ExtResource( 1 )]
-margin_left = 304.0
-margin_right = 604.0
+margin_left = 355.0
+margin_right = 707.0
 margin_bottom = 284.0
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
 margin_top = 288.0
-margin_right = 604.0
+margin_right = 707.0
 margin_bottom = 572.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -61,10 +62,10 @@ __meta__ = {
 }
 
 [node name="koude03" parent="VBoxContainer/HBoxContainer3" instance=ExtResource( 1 )]
-margin_right = 300.0
+margin_right = 351.0
 margin_bottom = 284.0
 
 [node name="koude04" parent="VBoxContainer/HBoxContainer3" instance=ExtResource( 1 )]
-margin_left = 304.0
-margin_right = 604.0
+margin_left = 355.0
+margin_right = 707.0
 margin_bottom = 284.0

--- a/ChoukaBaraGame/Scripts/Gara/GaraPopup.gd
+++ b/ChoukaBaraGame/Scripts/Gara/GaraPopup.gd
@@ -18,7 +18,7 @@ var multiplier:float;
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	randomize()
+	randomize()	
 	if(is_Debug):
 		multiplier = 0.01
 	else:
@@ -28,6 +28,7 @@ func _ready():
 	garaList.clear()
 	koude04.connect("roll_finished",self,"_on_koude_roll_finished")
 	addButton.visible = false
+	var _error = connect("popup_hide",self,"_on_garapopup_hide")
 	popup_centered()
 	while repeat:
 		list.append(getState())
@@ -48,8 +49,7 @@ func _ready():
 			yield(self,"custom_action")
 	
 	addButton.visible = false
-	okButton.visible = true
-	emit_signal("gara_completed",garaList)
+	okButton.visible = true	
 
 func getState() -> bool:
 #	return true
@@ -73,3 +73,7 @@ func update_gara_text() -> String:
 	
 	text += scoreText
 	return text
+
+func _on_garapopup_hide():
+	emit_signal("gara_completed",garaList)
+	emit_signal("confirmed")

--- a/ChoukaBaraGame/Scripts/Player/Player.gd
+++ b/ChoukaBaraGame/Scripts/Player/Player.gd
@@ -44,7 +44,7 @@ func _ready():
 func _on_homeBase_area_entered(area:Area2D):
 	var pawn = area.get_parent()
 	pawn.call_deferred("disableHitBox")
-		
+
 func allignNavigationNode() -> void:
 	navigation.position = PlayerInfo.navigationData[player_index].position
 	navigation.rotation_degrees = PlayerInfo.navigationData[player_index].rotation
@@ -54,3 +54,10 @@ func allignNavigationNode() -> void:
 func getHomebasePosition() -> Vector2:
 	return homeBase.position
 
+func SetZIndex(bringFront:bool):
+	for child in get_children():
+		if child is Pawn:
+			if bringFront:
+				(child as Pawn).z_index = 1
+			else:
+				(child as Pawn).z_index = 0

--- a/ChoukaBaraGame/Scripts/StateMachine/GameStateMachine/SelectPawn.gd
+++ b/ChoukaBaraGame/Scripts/StateMachine/GameStateMachine/SelectPawn.gd
@@ -5,12 +5,14 @@ func enter(logic_root):
 #	when player finishes the turn or cannot move any pawn  
 	if(PlayerInfo.garaList.empty()):
 		yield(get_tree().create_timer(0.5),"timeout")
+		PlayerInfo.active_player.SetZIndex(false)
 		if(PlayerInfo.active_player && PlayerInfo.active_player.needsReRoll):
 			PlayerInfo.active_player.needsReRoll = false
 			emit_signal("finished","CalculateGara")
 		else:
 			emit_signal("finished","SelectNextPlayer")
 	else:
+		PlayerInfo.active_player.SetZIndex(true)
 		yield(PlayerInfo.active_player,"pawnSelected")
 		PlayerInfo.active_player.selectedPawn.call_deferred("enableHitBox",true)
 		emit_signal("finished","MovePawn")


### PR DESCRIPTION
The pawns were geting hidden behind other sprites  previousely.
I have updated the z-index of all the pawns belonging to the selcted player so that they are drawn above other sprites during selection of pawn for movement. After the movement is complete the z-index is reset back to 0 so that teh next player pawns can be drawn in front